### PR TITLE
Correct Box IDs

### DIFF
--- a/src/main/io/rc_controls.h
+++ b/src/main/io/rc_controls.h
@@ -23,7 +23,7 @@ typedef enum {
     BOXHORIZON,
     BOXBARO,
     // BOXVARIO,
-    BOXMAG,
+    BOXMAG = 5,
     BOXHEADFREE,
     BOXHEADADJ,
     BOXCAMSTAB,


### PR DESCRIPTION
Correct the box IDs to match MSP and the Cleanflight documentation. As identified in #509